### PR TITLE
Updated README to not use moblie links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![image](https://img.shields.io/pypi/dm/audible.svg)](https://pypi.org/project/audible/)
 
 **Audible is a Python low-level interface to communicate with the non-publicly 
-[Audible](https://en.m.wikipedia.org/wiki/Audible_(service)) API.** 
+[Audible](https://en.wikipedia.org/wiki/Audible_(service)) API.** 
 
 It enables Python developers to create there own Audible services. 
 Asynchronous communication with the Audible API is supported.


### PR DESCRIPTION
One of the links to Wikipedia was to the mobile optimized site. This changes it to the desktop optimized site.